### PR TITLE
Add Chinese/English language switch in settings

### DIFF
--- a/src/customize.sh
+++ b/src/customize.sh
@@ -33,6 +33,12 @@ unzip -o "$ZIPFILE" "service.sh" -d "$MODPATH" >/dev/null 2>&1
 unzip -o "$ZIPFILE" "uninstall.sh" -d "$MODPATH" >/dev/null 2>&1
 unzip -o "$ZIPFILE" "webroot/*" -d "$MODPATH" >/dev/null 2>&1
 
+# 将选择的语言写入文件，供 WebUI 首次启动时使用
+WEBUI_LANG_FILE="$AGH_DIR/webui_lang"
+echo "$language" > "$WEBUI_LANG_FILE"
+chmod 644 "$WEBUI_LANG_FILE"
+info "- 📝 WebUI default language set to: $language" "- 📝 WebUI 默认语言设置为: $language"
+
 extract_keep_config() {
   info "- 🌈 Keeping old configuration files..." "- 🌈 保留原来的配置文件..."
   info "- 📜 Extracting script files..." "- 📜 正在解压脚本文件..."

--- a/src/webroot/app.js
+++ b/src/webroot/app.js
@@ -1,9 +1,132 @@
 /**
  * AdGuardHome for Root - WebUI Application
- * 
- * KernelSU API: ksu.exec(cmd) returns stdout string synchronously
- * KernelSU API: ksu.toast(msg) shows a toast
+ * 内嵌中英文翻译，支持切换
  */
+
+// ==================== 语言数据（内嵌） ====================
+var langData = {
+  zh: {
+    // 状态
+    running: '运行中',
+    stopped: '已停止',
+    loading: '加载中...',
+    noapi: '无 API',
+    // 统计卡片
+    stats_title: '查询日志统计',
+    stat_queries: 'DNS查询',
+    stat_blocked: '规则拦截',
+    stat_time: '处理耗时',
+    // 按钮
+    btn_start: '启动',
+    btn_stop: '停止',
+    btn_restart: '重启',
+    btn_debug: '调试信息',
+    btn_save: '保存设置',
+    btn_webpanel: 'AdGuardHome 网页管理面板',
+    // 设置页面
+    settings_title: '设置',
+    iptables_title: '启用 iptables',
+    iptables_desc: '通过 iptables 重定向 DNS 请求',
+    ipv6_title: '阻止 IPv6 DNS',
+    ipv6_desc: '阻止 IPv6 的 DNS 请求',
+    redir_port: '重定向端口（必须与 AdGuardHome DNS 端口一致）',
+    run_user: '运行用户',
+    run_group: '运行用户组',
+    bypass_dest: '绕过目标（空格分隔）',
+    bypass_src: '绕过来源（空格分隔）',
+    // Toast 消息
+    save_ok: '设置已保存成功',
+    save_fail: '保存设置失败',
+    start_ok: '启动成功',
+    stop_ok: '停止成功',
+    restart_ok: '重启成功',
+    start_fail: '启动失败',
+    stop_fail: '停止失败',
+    restart_fail: '重启失败',
+    debug_ok: '调试信息已收集至 /data/adb/agh/debug.log',
+    // 日志
+    log_empty: '暂无日志',
+    // 页脚
+    mit: 'MIT 协议',
+    // 标签栏
+    tab_main: '主页',
+    tab_settings: '设置',
+    // 帮助弹窗
+    help_title: '指标说明',
+    help_dns: 'DNS查询',
+    help_dns_desc: 'AdGuard Home 核心处理的 DNS 查询总数。',
+    help_blocked: '规则拦截',
+    help_blocked_desc: '被过滤规则拦截的 DNS 请求数量。',
+    help_time: '处理耗时',
+    help_time_desc: '处理每个 DNS 请求的平均耗时（秒）。',
+    help_note: '数据通过 AdGuard Home OpenAPI 实时获取，统计周期由核心配置决定。',
+    help_close: '关闭',
+    // 语言切换
+    language_title: '语言',
+    language_desc: '选择界面显示语言',
+    // 认证
+    auth_hint: '认证失败，请输入 AdGuardHome Web UI 账号密码',
+    username: '用户名',
+    password: '密码',
+    confirm: '确认'
+  },
+  en: {
+    running: 'Running',
+    stopped: 'Stopped',
+    loading: 'Loading...',
+    noapi: 'No API',
+    stats_title: 'Query Log Statistics',
+    stat_queries: 'DNS queries',
+    stat_blocked: 'Blocked',
+    stat_time: 'Avg time',
+    btn_start: 'Start',
+    btn_stop: 'Stop',
+    btn_restart: 'Restart',
+    btn_debug: 'Debug Info',
+    btn_save: 'Save Settings',
+    btn_webpanel: 'AdGuardHome Web Panel',
+    settings_title: 'Settings',
+    iptables_title: 'Enable Iptables',
+    iptables_desc: 'Redirect DNS requests via iptables',
+    ipv6_title: 'Block IPv6 DNS',
+    ipv6_desc: 'Block DNS requests over IPv6',
+    redir_port: 'Redirect Port (must match AdGuardHome DNS port)',
+    run_user: 'Run User',
+    run_group: 'Run User Group',
+    bypass_dest: 'Bypass Destinations (space-separated)',
+    bypass_src: 'Bypass Sources (space-separated)',
+    save_ok: 'Settings saved successfully',
+    save_fail: 'Failed to save settings',
+    start_ok: 'Start successful',
+    stop_ok: 'Stop successful',
+    restart_ok: 'Restart successful',
+    start_fail: 'Start failed',
+    stop_fail: 'Stop failed',
+    restart_fail: 'Restart failed',
+    debug_ok: 'Debug info collected to /data/adb/agh/debug.log',
+    log_empty: 'No log entries',
+    mit: 'MIT License',
+    tab_main: 'Main',
+    tab_settings: 'Settings',
+    help_title: 'Statistics Help',
+    help_dns: 'DNS Queries',
+    help_dns_desc: 'Total number of DNS queries processed by AdGuard Home.',
+    help_blocked: 'Blocked',
+    help_blocked_desc: 'Number of DNS requests blocked by filtering rules.',
+    help_time: 'Processing Time',
+    help_time_desc: 'Average processing time per DNS request (seconds).',
+    help_note: 'Data is obtained via AdGuard Home OpenAPI, and the statistical period is determined by the core configuration.',
+    help_close: 'Close',
+    language_title: 'Language',
+    language_desc: 'Select interface language',
+    auth_hint: 'Authentication failed, please enter AdGuardHome Web UI credentials',
+    username: 'Username',
+    password: 'Password',
+    confirm: 'Confirm'
+  }
+};
+
+var curLang = localStorage.getItem('agh_lang') || 'zh';
 
 // ==================== Module API Layer ====================
 var ModuleAPI = {
@@ -21,11 +144,6 @@ var ModuleAPI = {
     return this._api !== null;
   },
 
-  /**
-   * Execute shell command SYNCHRONOUSLY.
-   * ksu.exec(cmd) returns stdout string directly.
-   * Returns { errno, stdout }
-   */
   exec: function(command) {
     if (!this._api) {
       return { errno: -1, stdout: '' };
@@ -100,7 +218,6 @@ function switchTab(index) {
   container.classList.remove('no-transition');
   container.style.transform = 'translateX(' + (-index * 50) + '%)';
 
-  // Update floating tab active state
   var tabs = document.querySelectorAll('.floating-tab-item');
   for (var i = 0; i < tabs.length; i++) {
     if (i === index) {
@@ -110,7 +227,6 @@ function switchTab(index) {
     }
   }
 
-  // Always show floating tab when switching pages
   var floatingTab = document.getElementById('floatingTab');
   if (floatingTab) {
     floatingTab.classList.remove('tab-hidden');
@@ -201,6 +317,28 @@ function switchTab(index) {
   });
 })();
 
+// ==================== 应用语言（更新所有带 data-i18n 的元素） ====================
+function applyLanguage() {
+  var l = langData[curLang];
+  document.querySelectorAll('[data-i18n]').forEach(function(el) {
+    var key = el.getAttribute('data-i18n');
+    if (l[key] !== undefined) {
+      el.innerText = l[key];
+    }
+  });
+  // 更新状态栏文字（特殊处理，因为状态动态变化）
+  var statusEl = document.getElementById('statusText');
+  if (statusEl) {
+    var isRunningNow = document.getElementById('statusBadge').classList.contains('running');
+    statusEl.innerText = isRunningNow ? l.running : l.stopped;
+  }
+  // 高亮当前语言按钮
+  document.querySelectorAll('.lang-option-btn').forEach(function(btn) {
+    if (btn.dataset.lang === curLang) btn.classList.add('active');
+    else btn.classList.remove('active');
+  });
+}
+
 // ==================== Status Check ====================
 function checkStatus() {
   var badge = document.getElementById('statusBadge');
@@ -221,7 +359,7 @@ function checkStatus() {
 
   isRunning = running;
   badge.className = 'status-badge ' + (running ? 'running' : 'stopped');
-  statusText.textContent = running ? 'Running' : 'Stopped';
+  statusText.textContent = running ? langData[curLang].running : langData[curLang].stopped;
 
   pidBadge.textContent = 'PID: ' + pid;
 
@@ -298,9 +436,9 @@ function saveSettings() {
   if (result.errno === 0) {
     settingsChanged = false;
     document.getElementById('btnSaveSettings').disabled = true;
-    showToast('Settings saved successfully', 'success');
+    showToast(langData[curLang].save_ok, 'success');
   } else {
-    showToast('Failed to save settings', 'error');
+    showToast(langData[curLang].save_fail, 'error');
   }
 
   showLoading(false);
@@ -315,7 +453,7 @@ function loadLog() {
     var raw = (result.stdout || '').trim();
     var lines = raw.split('::NL::').filter(function(l) { return l !== ''; });
     var content = lines.join('\n');
-    logViewer.textContent = content || 'No log entries';
+    logViewer.textContent = content || langData[curLang].log_empty;
     logViewer.scrollTop = logViewer.scrollHeight;
   }
 }
@@ -432,10 +570,11 @@ function controlAdGuard(action) {
   var result = ModuleAPI.exec(cmd);
 
   if (result.errno === 0) {
-    var label = action.charAt(0).toUpperCase() + action.slice(1);
-    showToast(label + ' successful', 'success');
+    var okKey = action + '_ok';
+    showToast(langData[curLang][okKey], 'success');
   } else {
-    showToast(action + ' failed', 'error');
+    var failKey = action + '_fail';
+    showToast(langData[curLang][failKey], 'error');
   }
 
   setTimeout(function() {
@@ -455,7 +594,7 @@ function openAdGuardHome() {
 function collectDebugInfo() {
   showLoading(true);
   ModuleAPI.exec(SCRIPT_DIR + '/debug.sh 2>/dev/null');
-  showToast('Debug info collected to ' + AGH_DIR + '/debug.log', 'success');
+  showToast(langData[curLang].debug_ok, 'success');
   showLoading(false);
 }
 
@@ -507,7 +646,7 @@ function init() {
   if (!ModuleAPI.isAvailable()) {
     document.getElementById('noApiWarning').style.display = 'block';
     document.getElementById('statusBadge').className = 'status-badge stopped';
-    document.getElementById('statusText').textContent = 'No API';
+    document.getElementById('statusText').textContent = langData[curLang].noapi;
     return;
   }
 
@@ -518,6 +657,17 @@ function init() {
   loadLog();
   loadStats();
   setupScrollHideTab();
+
+  // 绑定语言切换按钮
+  document.querySelectorAll('.lang-option-btn').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      curLang = this.dataset.lang;
+      localStorage.setItem('agh_lang', curLang);
+      applyLanguage();
+      checkStatus(); // 刷新状态文本
+    });
+  });
+  applyLanguage();
 
   switchTab(0);
 }

--- a/src/webroot/app.js
+++ b/src/webroot/app.js
@@ -126,7 +126,7 @@ var langData = {
   }
 };
 
-var curLang = localStorage.getItem('agh_lang') || 'zh';
+var curLang;
 
 // ==================== Module API Layer ====================
 var ModuleAPI = {
@@ -649,6 +649,20 @@ function init() {
     document.getElementById('statusText').textContent = langData[curLang].noapi;
     return;
   }
+
+  // 首次打开时，如果 localStorage 中没有语言设置，则从模块安装时写入的文件读取默认语言
+if (!localStorage.getItem('agh_lang')) {
+  var result = ModuleAPI.exec('cat /data/adb/agh/webui_lang 2>/dev/null');
+  var lang = result.stdout.trim();
+  if (lang === 'zh' || lang === 'en') {
+    curLang = lang;
+  } else {
+    curLang = 'zh';
+  }
+  localStorage.setItem('agh_lang', curLang);
+} else {
+  curLang = localStorage.getItem('agh_lang');
+}
 
   loadSettings();
   checkStatus();

--- a/src/webroot/index.html
+++ b/src/webroot/index.html
@@ -5,23 +5,43 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 <title>AdGuardHome for Root</title>
 <link rel="stylesheet" href="style.css">
+<style>
+.lang-options {
+  display: flex;
+  gap: 12px;
+  margin-top: 8px;
+}
+.lang-option-btn {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 6px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: var(--transition);
+}
+.lang-option-btn.active {
+  background: var(--primary);
+  color: white;
+  border-color: var(--primary);
+}
+</style>
 </head>
 <body>
 
 <div class="app-wrapper">
-  <!-- Pages Container -->
   <div class="pages-container" id="pagesContainer">
-
     <!-- Page 1: Main -->
     <div class="page page-main" id="pageMain">
       <div class="container">
-        <!-- Header -->
         <div class="header">
           <div class="header-icon">
             <svg viewBox="0 0 24 24"><path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 10.99h7c-.53 4.12-3.28 7.79-7 8.94V12H5V6.3l7-3.11v8.8z"/></svg>
           </div>
           <h1>AdGuardHome for Root</h1>
-          <div class="version" id="versionText">v20260315</div>
+          <div class="version" id="versionText">v20260419</div>
           <div class="status-row">
             <span class="status-badge loading" id="statusBadge">
               <span class="status-dot"></span>
@@ -31,71 +51,62 @@
           </div>
         </div>
 
-        <!-- No API Warning -->
         <div class="no-api-warning" id="noApiWarning" style="display:none;">
           <h3>⚠️ Module API Not Available</h3>
           <p>This WebUI requires KernelSU or APatch module manager. Please open this page from the module manager app.</p>
         </div>
 
-        <!-- Statistics -->
         <div class="card card-stats">
           <div class="card-title">
             <svg class="card-title-icon" viewBox="0 0 24 24"><path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"/></svg>
-            Query Log Statistics
+            <span data-i18n="stats_title">Query Log Statistics</span>
             <button class="btn-help" onclick="toggleStatsHelp()">?</button>
           </div>
-          <!-- Stats Data View -->
           <div class="stats-grid" id="statsDataView">
             <div class="stat-item">
               <div class="stat-value" id="statQueries">-</div>
-              <div class="stat-label">DNS查询</div>
+              <div class="stat-label" data-i18n="stat_queries">DNS查询</div>
             </div>
             <div class="stat-item">
               <div class="stat-value" id="statBlocked">-</div>
-              <div class="stat-label">规则拦截</div>
+              <div class="stat-label" data-i18n="stat_blocked">规则拦截</div>
             </div>
             <div class="stat-item">
               <div class="stat-value" id="statTime">-</div>
-              <div class="stat-label">处理耗时</div>
+              <div class="stat-label" data-i18n="stat_time">处理耗时</div>
             </div>
           </div>
-          <!-- Credential Input View (hidden by default) -->
           <div class="stats-auth-form" id="statsAuthView" style="display:none;">
-            <div class="stats-auth-hint">认证失败，请输入 AdGuardHome Web UI 账号密码</div>
+            <div class="stats-auth-hint" data-i18n="auth_hint">认证失败，请输入 AdGuardHome Web UI 账号密码</div>
             <div class="input-group">
-              <label class="input-label">Username</label>
+              <label class="input-label" data-i18n="username">Username</label>
               <input type="text" class="input-field" id="authUser" placeholder="root" value="root">
             </div>
             <div class="input-group">
-              <label class="input-label">Password</label>
+              <label class="input-label" data-i18n="password">Password</label>
               <input type="password" class="input-field" id="authPassword" placeholder="root" value="root">
             </div>
-            <button class="btn btn-primary btn-full" onclick="submitCredentials()" style="margin-top:8px;">确认</button>
+            <button class="btn btn-primary btn-full" onclick="submitCredentials()" style="margin-top:8px;" data-i18n="confirm">确认</button>
           </div>
         </div>
 
-        <!-- Open Web Panel -->
         <div class="card card-action">
-          <button class="btn btn-link btn-full" onclick="openAdGuardHome()">
-            AdGuardHome Web Panel
-          </button>
+          <button class="btn btn-link btn-full" onclick="openAdGuardHome()" data-i18n="btn_webpanel">AdGuardHome Web Panel</button>
         </div>
 
-        <!-- Control -->
         <div class="card">
           <div class="control-buttons">
-            <button class="btn btn-primary" id="btnStart" onclick="controlAdGuard('start')" disabled>Start</button>
-            <button class="btn btn-danger" id="btnStop" onclick="controlAdGuard('stop')" disabled>Stop</button>
-            <button class="btn btn-secondary" id="btnRestart" onclick="controlAdGuard('restart')" disabled>Restart</button>
-            <button class="btn btn-secondary" onclick="collectDebugInfo()">Debug Info</button>
+            <button class="btn btn-primary" id="btnStart" onclick="controlAdGuard('start')" disabled data-i18n="btn_start">Start</button>
+            <button class="btn btn-danger" id="btnStop" onclick="controlAdGuard('stop')" disabled data-i18n="btn_stop">Stop</button>
+            <button class="btn btn-secondary" id="btnRestart" onclick="controlAdGuard('restart')" disabled data-i18n="btn_restart">Restart</button>
+            <button class="btn btn-secondary" onclick="collectDebugInfo()" data-i18n="btn_debug">Debug Info</button>
           </div>
           <div class="log-viewer" id="logViewer"></div>
         </div>
 
-        <!-- Footer -->
         <div class="footer">
           <p>AdGuardHome for Root by <a href="https://github.com/twoone-3">twoone3</a></p>
-          <p style="margin-top:4px;">MIT License · <a href="https://github.com/twoone-3/AdGuardHomeForRoot">GitHub</a></p>
+          <p style="margin-top:4px;"><span data-i18n="mit">MIT License</span> · <a href="https://github.com/twoone-3/AdGuardHomeForRoot">GitHub</a></p>
         </div>
       </div>
     </div>
@@ -103,18 +114,16 @@
     <!-- Page 2: Settings -->
     <div class="page page-settings" id="pageSettings">
       <div class="container">
-        <!-- Settings Header -->
         <div class="settings-header">
-          <div class="card-title">Settings</div>
+          <div class="card-title" data-i18n="settings_title">Settings</div>
         </div>
 
-        <!-- Settings Content -->
         <div class="card">
           <div class="setting-group">
             <div class="setting-row">
               <div class="setting-label">
-                <div class="title">Enable Iptables</div>
-                <div class="desc">Redirect DNS requests via iptables</div>
+                <div class="title" data-i18n="iptables_title">Enable Iptables</div>
+                <div class="desc" data-i18n="iptables_desc">Redirect DNS requests via iptables</div>
               </div>
               <label class="toggle">
                 <input type="checkbox" id="setEnableIptables" onchange="onSettingChange()">
@@ -123,8 +132,8 @@
             </div>
             <div class="setting-row">
               <div class="setting-label">
-                <div class="title">Block IPv6 DNS</div>
-                <div class="desc">Block DNS requests over IPv6</div>
+                <div class="title" data-i18n="ipv6_title">Block IPv6 DNS</div>
+                <div class="desc" data-i18n="ipv6_desc">Block DNS requests over IPv6</div>
               </div>
               <label class="toggle">
                 <input type="checkbox" id="setBlockIpv6" onchange="onSettingChange()">
@@ -133,33 +142,43 @@
             </div>
           </div>
 
+          <!-- 语言切换选项组 -->
+          <div class="setting-group">
+            <div class="setting-label">
+              <div class="title" data-i18n="language_title">语言</div>
+              <div class="desc" data-i18n="language_desc">选择界面显示语言</div>
+            </div>
+            <div class="lang-options">
+              <button class="lang-option-btn" data-lang="zh">中文</button>
+              <button class="lang-option-btn" data-lang="en">English</button>
+            </div>
+          </div>
+
           <div class="setting-group">
             <div class="input-group">
-              <label class="input-label">Redirect Port (must match AdGuardHome DNS port)</label>
+              <label class="input-label" data-i18n="redir_port">Redirect Port (must match AdGuardHome DNS port)</label>
               <input type="number" class="input-field" id="setRedirPort" placeholder="5591" onchange="onSettingChange()">
             </div>
             <div class="input-group">
-              <label class="input-label">Run User</label>
+              <label class="input-label" data-i18n="run_user">Run User</label>
               <input type="text" class="input-field" id="setAdgUser" placeholder="root" onchange="onSettingChange()">
             </div>
             <div class="input-group">
-              <label class="input-label">Run User Group</label>
+              <label class="input-label" data-i18n="run_group">Run User Group</label>
               <input type="text" class="input-field" id="setAdgGroup" placeholder="net_raw" onchange="onSettingChange()">
             </div>
             <div class="input-group">
-              <label class="input-label">Bypass Destinations (space-separated)</label>
+              <label class="input-label" data-i18n="bypass_dest">Bypass Destinations (space-separated)</label>
               <input type="text" class="input-field" id="setIgnoreDest" placeholder="" onchange="onSettingChange()">
             </div>
             <div class="input-group">
-              <label class="input-label">Bypass Sources (space-separated)</label>
+              <label class="input-label" data-i18n="bypass_src">Bypass Sources (space-separated)</label>
               <input type="text" class="input-field" id="setIgnoreSrc" placeholder="" onchange="onSettingChange()">
             </div>
           </div>
 
           <div class="setting-group" style="margin-bottom:0;">
-            <button class="btn btn-primary btn-full" id="btnSaveSettings" onclick="saveSettings()" disabled>
-              Save Settings
-            </button>
+            <button class="btn btn-primary btn-full" id="btnSaveSettings" onclick="saveSettings()" disabled data-i18n="btn_save">Save Settings</button>
           </div>
         </div>
       </div>
@@ -167,44 +186,39 @@
 
   </div>
 
-  <!-- Floating Tab Bar -->
   <div class="floating-tab" id="floatingTab">
     <div class="floating-tab-item active" data-page="0" onclick="switchTab(0)">
       <svg class="tab-icon" viewBox="0 0 24 24"><path d="M12 2L2 12h3v8h6v-6h2v6h6v-8h3L12 2zm0 2.84L19.16 12H18v8h-4v-6H10v6H6v-8H4.84L12 4.84z"/></svg>
-      <span class="tab-label">Main</span>
+      <span class="tab-label" data-i18n="tab_main">Main</span>
     </div>
     <div class="floating-tab-item" data-page="1" onclick="switchTab(1)">
       <svg class="tab-icon" viewBox="0 0 24 24"><path d="M19.14,12.94c0.04-0.3,0.06-0.61,0.06-0.94c0-0.32-0.02-0.64-0.07-0.94l2.03-1.58c0.18-0.14,0.23-0.41,0.12-0.61 l-1.92-3.32c-0.12-0.22-0.37-0.29-0.59-0.22l-2.39,0.96c-0.5-0.38-1.03-0.7-1.62-0.94L14.4,2.81c-0.04-0.24-0.24-0.41-0.48-0.41 h-3.84c-0.24,0-0.43,0.17-0.47,0.41L9.25,5.35C8.66,5.59,8.12,5.92,7.63,6.29L5.24,5.33c-0.22-0.08-0.47,0-0.59,0.22L2.74,8.87 C2.62,9.08,2.66,9.34,2.86,9.48l2.03,1.58C4.84,11.36,4.8,11.69,4.8,12s0.02,0.64,0.07,0.94l-2.03,1.58 c-0.18,0.14-0.23,0.41-0.12,0.61l1.92,3.32c0.12,0.22,0.37,0.29,0.59,0.22l2.39-0.96c0.5,0.38,1.03,0.7,1.62,0.94l0.36,2.54 c0.05,0.24,0.24,0.41,0.48,0.41h3.84c0.24,0,0.44-0.17,0.47-0.41l0.36-2.54c0.59-0.24,1.13-0.56,1.62-0.94l2.39,0.96 c0.22,0.08,0.47,0,0.59-0.22l1.92-3.32c0.12-0.22,0.07-0.47-0.12-0.61L19.14,12.94z M12,15.6c-1.98,0-3.6-1.62-3.6-3.6 s1.62-3.6,3.6-3.6s3.6,1.62,3.6,3.6S13.98,15.6,12,15.6z"/></svg>
-      <span class="tab-label">Settings</span>
+      <span class="tab-label" data-i18n="tab_settings">Settings</span>
     </div>
   </div>
 </div>
 
-<!-- Stats Help Modal -->
 <div class="help-modal-overlay" id="statsHelpOverlay" onclick="closeStatsHelp()">
   <div class="help-modal" onclick="event.stopPropagation()">
-    <div class="help-modal-title">指标说明</div>
+    <div class="help-modal-title" data-i18n="help_title">指标说明</div>
     <div class="help-modal-item">
-      <strong>DNS查询</strong>
-      <p>AdGuard Home 核心处理的 DNS 查询总数。</p>
+      <strong data-i18n="help_dns">DNS查询</strong>
+      <p data-i18n="help_dns_desc">AdGuard Home 核心处理的 DNS 查询总数。</p>
     </div>
     <div class="help-modal-item">
-      <strong>规则拦截</strong>
-      <p>被过滤规则拦截的 DNS 请求数量。</p>
+      <strong data-i18n="help_blocked">规则拦截</strong>
+      <p data-i18n="help_blocked_desc">被过滤规则拦截的 DNS 请求数量。</p>
     </div>
     <div class="help-modal-item">
-      <strong>处理耗时</strong>
-      <p>处理每个 DNS 请求的平均耗时（秒）。</p>
+      <strong data-i18n="help_time">处理耗时</strong>
+      <p data-i18n="help_time_desc">处理每个 DNS 请求的平均耗时（秒）。</p>
     </div>
-    <div class="help-modal-note">数据通过 AdGuard Home OpenAPI 实时获取，统计周期由核心配置决定。</div>
-    <button class="btn btn-secondary btn-full" onclick="closeStatsHelp()" style="margin-top:12px;">关闭</button>
+    <div class="help-modal-note" data-i18n="help_note">数据通过 AdGuard Home OpenAPI 实时获取，统计周期由核心配置决定。</div>
+    <button class="btn btn-secondary btn-full" onclick="closeStatsHelp()" style="margin-top:12px;" data-i18n="help_close">关闭</button>
   </div>
 </div>
 
-<!-- Toast Container -->
 <div class="toast-container" id="toastContainer"></div>
-
-<!-- Loading Overlay -->
 <div class="loading-overlay" id="loadingOverlay" style="display:none;">
   <div class="spinner"></div>
 </div>


### PR DESCRIPTION
## What does this PR do?
Adds a language switcher in the Settings page, supporting **Chinese (Simplified)** and **English**.  
All UI texts (including status, buttons, settings labels, help modal, footer, etc.) can be toggled between the two languages without reloading the page. The selected language is saved in `localStorage` and persists after refresh.

## Key changes
- **New feature**: Language toggle with two buttons (`中文` / `English`) placed in Settings page.
- **i18n data**: Embedded inside `app.js` (no extra HTTP request) for faster loading.
- **Dynamic translation**: Uses `data-i18n` attributes in HTML; JS function `applyLanguage()` updates all texts on switch.
- **Preserved original behavior**: All existing functionality (start/stop, settings save, stats, logs, etc.) unchanged.

## Files modified
- `index.html`: Added language switch UI, added `data-i18n` to all translatable elements.
- `app.js`: Added `langData` object and `applyLanguage()`; modified `checkStatus()`, `controlAdGuard()`, `saveSettings()`, `loadLog()`, `collectDebugInfo()` to use translated strings; added language switching event binding.

## Testing performed
- Tested on real device with KernelSU WebUI.
- Switching between Chinese and English updates every UI element correctly.
- After refresh, language choice is remembered.
- No regression on module control (start/stop/restart) or statistics fetching.

## Additional notes
- This PR does **not** modify `style.css` or any existing logic structure.
- Translation keys are minimal (only what appears on screen). Future language additions can be done by extending `langData`.

## Screenshots
<img width="1264" height="2780" alt="Screenshot_2026-04-21-20-58-09-45_676e4cb4cfb833a96b248618a803cf16" src="https://github.com/user-attachments/assets/d22be37f-26e2-4ead-bb30-1102c492063a" />
<img width="1264" height="2780" alt="Screenshot_2026-04-21-20-58-12-09_676e4cb4cfb833a96b248618a803cf16" src="https://github.com/user-attachments/assets/86e914d0-0163-43e8-9062-e6b46c734fa8" />
<img width="1264" height="2780" alt="Screenshot_2026-04-21-20-58-15-69_676e4cb4cfb833a96b248618a803cf16" src="https://github.com/user-attachments/assets/a42d447c-cf65-46b2-801b-6cc81176ce76" />
<img width="1264" height="2780" alt="Screenshot_2026-04-21-20-58-18-25_676e4cb4cfb833a96b248618a803cf16" src="https://github.com/user-attachments/assets/2587a3ed-b948-417d-b712-1bb140130bf4" />
